### PR TITLE
Feat/front/pagelayout - bottom Nav bar css 변경

### DIFF
--- a/client/components/layout/layoutWithFooter/LayoutWithFooter.tsx
+++ b/client/components/layout/layoutWithFooter/LayoutWithFooter.tsx
@@ -12,7 +12,7 @@ const LayoutWithFooter = ({ children }: defaultLayoutPropsType) => {
         <div className="max-w-2xl min-w-[390px] mx-auto h-[100vh] flex flex-col">
           <MainHeader />
           {children}
-          <div className="pb-[70px]">
+          <div className="pb-[56px]">
             <Footer />
           </div>
           <Navigation />

--- a/client/components/organisms/bottomNav/bottomNav.tsx
+++ b/client/components/organisms/bottomNav/bottomNav.tsx
@@ -45,13 +45,7 @@ export default function Navigation() {
   return (
     <Box
       sx={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        maxWidth: '672px',
-        margin: 'auto',
-        minWidth: '390px',
+        height: 70,
       }}
     >
       <CssBaseline />
@@ -60,7 +54,13 @@ export default function Navigation() {
           showLabels
           value={router.pathname}
           sx={{
-            height: 70,
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            maxWidth: '672px',
+            margin: 'auto',
+            minWidth: '390px',
           }}
         >
           {NAVIGATION_LIST.map(({ label, icon, path }: any) => {


### PR DESCRIPTION
원래 경현님께서 bottom Nav bar에서 부모태그에 height을 부여하고, 자식태그에 position: fixed 부여했습니다.
레이아웃을 잡다가 이리저리 시도해보던 도중에 이를 반대로 바꿨었는데, 경현님께서 처음에 설정하신게 맞는 것 같아 원래대로 수정했습니다.(제가 수정한대로면 채팅방이나 내주변 페이지 컴포넌트와 bottom Nav가 겹칩니다.)
제대로 확인을 하고 풀리퀘 요청 했어야했는데 죄송합니다~!